### PR TITLE
Fix outlier export bug and add custom label tracking

### DIFF
--- a/backend/alembic/versions/95fc7a05cf71_add_is_custom_label_to_images.py
+++ b/backend/alembic/versions/95fc7a05cf71_add_is_custom_label_to_images.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('images', sa.Column('is_custom_label', sa.Boolean(), server_default=sa.text('false'), nullable=True))
+    op.add_column('images', sa.Column('is_custom_label', sa.Boolean(), server_default=sa.text('false'), nullable=False))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/95fc7a05cf71_add_is_custom_label_to_images.py
+++ b/backend/alembic/versions/95fc7a05cf71_add_is_custom_label_to_images.py
@@ -1,0 +1,24 @@
+"""add is_custom_label to images
+
+Revision ID: 95fc7a05cf71
+Revises: 003_add_episode_speakers
+Create Date: 2026-01-09 23:35:10.060807
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '95fc7a05cf71'
+down_revision = '003_add_episode_speakers'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('images', sa.Column('is_custom_label', sa.Boolean(), server_default=sa.text('false'), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('images', 'is_custom_label')

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -175,6 +175,7 @@ class Image(Base):
     current_label = Column(String(255), nullable=True)
     annotation_status = Column(String(20), server_default=text("'pending'"))
     annotated_at = Column(DateTime(timezone=True), nullable=True)
+    is_custom_label = Column(Boolean, server_default=text("false"))
 
     cluster = relationship("Cluster", back_populates="images")
     episode = relationship("Episode", back_populates="images")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -175,7 +175,7 @@ class Image(Base):
     current_label = Column(String(255), nullable=True)
     annotation_status = Column(String(20), server_default=text("'pending'"))
     annotated_at = Column(DateTime(timezone=True), nullable=True)
-    is_custom_label = Column(Boolean, server_default=text("false"))
+    is_custom_label = Column(Boolean, nullable=False, server_default=text("false"))
 
     cluster = relationship("Cluster", back_populates="images")
     episode = relationship("Episode", back_populates="images")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -110,6 +110,7 @@ class Image(ImageBase):
     current_label: Optional[str] = None
     annotation_status: str
     annotated_at: Optional[datetime] = None
+    is_custom_label: bool = False
 
     class Config:
         from_attributes = True

--- a/backend/app/services/cluster_service.py
+++ b/backend/app/services/cluster_service.py
@@ -293,6 +293,7 @@ class ClusterService:
             {
                 "current_label": normalized_label,
                 "annotation_status": "annotated",
+                "is_custom_label": annotation.is_custom_label,
                 "annotated_at": func.now(),
             },
             synchronize_session=False,
@@ -398,7 +399,10 @@ class ClusterService:
                 .update(
                     {
                         "current_label": normalized_label,
-                        "annotation_status": "annotated",
+                        "is_custom_label": annotation.is_custom_label,
+                        # NOTE: Do NOT update annotation_status here. Outliers must retain
+                        # status="outlier" so export_annotations() can correctly identify them
+                        # and include them in the "outliers" array rather than "image_paths".
                         "annotated_at": func.now(),
                     },
                     synchronize_session=False,

--- a/backend/tests/test_cluster_service.py
+++ b/backend/tests/test_cluster_service.py
@@ -694,7 +694,8 @@ class TestAnnotateOutliers:
             .first()
         )
         assert outlier_1.current_label == "Joey"
-        assert outlier_1.annotation_status == "annotated"
+        assert outlier_1.annotation_status == "outlier"
+        assert outlier_1.is_custom_label is False
         assert outlier_1.annotated_at is not None
 
         outlier_2 = (
@@ -732,7 +733,7 @@ class TestAnnotateOutliers:
         for img_id in outlier_ids:
             img = test_db.query(models.Image).filter(models.Image.id == img_id).first()
             assert img.current_label == "Ross"
-            assert img.annotation_status == "annotated"
+            assert img.annotation_status == "outlier"
 
     def test_annotate_outliers_custom_labels(
         self, test_db, sample_cluster_with_outliers
@@ -761,6 +762,8 @@ class TestAnnotateOutliers:
             .first()
         )
         assert outlier_1.current_label == "Gunther"
+        assert outlier_1.is_custom_label is True
+        assert outlier_1.annotation_status == "outlier"
 
         outlier_2 = (
             test_db.query(models.Image)
@@ -768,6 +771,8 @@ class TestAnnotateOutliers:
             .first()
         )
         assert outlier_2.current_label == "Janice"
+        assert outlier_2.is_custom_label is True
+        assert outlier_2.annotation_status == "outlier"
 
     def test_annotate_outliers_empty_list(self, test_db):
         """Test annotating with empty list (edge case)."""
@@ -900,14 +905,19 @@ class TestFullWorkflow:
         batch_result = service.annotate_cluster_batch(cluster_id, batch_annotation)
         assert batch_result["status"] == "completed"
 
-        # Verify final state: 22 Rachel + 3 others
+        # Verify final state: 22 Rachel (annotated) + 3 others (outlier)
         all_images = (
             test_db.query(models.Image)
             .filter(models.Image.cluster_id == cluster.id)
             .all()
         )
         assert len(all_images) == 25
-        assert all(img.annotation_status == "annotated" for img in all_images)
+        
+        # 22 should be annotated, 3 should be outlier
+        annotated_count = sum(1 for img in all_images if img.annotation_status == "annotated")
+        outlier_count = sum(1 for img in all_images if img.annotation_status == "outlier")
+        assert annotated_count == 22
+        assert outlier_count == 3
 
         rachel_count = sum(1 for img in all_images if img.current_label == "Rachel")
         assert rachel_count == 22


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where outlier annotations were not appearing in the exported JSON, and adds a new feature to distinguish custom labels from known speaker names.

## Bug Fix: Outliers Not Exported

### Problem
When exporting annotations, the JSON showed `"outliers_found": 0` even though clusters had `has_outliers: True` with counts up to 46.

### Root Cause
The `annotate_outliers()` function in `cluster_service.py` was incorrectly changing `annotation_status` from `"outlier"` to `"annotated"` when labeling outlier images. The export function correctly looks for `annotation_status == "outlier"`, so it found nothing.

### Fix
Removed the status change - outliers now retain their `annotation_status="outlier"` even after being labeled with a person name.

## New Feature: Custom Label Tracking

### Problem
When users select "Other" and enter a custom name (e.g., "DK1"), there was no way to distinguish this from a known speaker name in the export.

### Solution
- Added `is_custom_label` boolean column to the `images` table
- Export now includes `is_custom_label` for both cluster labels and individual outliers

### Export Format Example
```json
{
  "cluster-02": {
    "label": "monica",
    "is_custom_label": false,
    "confidence": "low",
    "outliers": [
      {
        "image_path": "friends_s01e05/cluster-02/scene_2.jpg",
        "label": "dk1",
        "is_custom_label": true
      }
    ]
  }
}
```

## Changes

| File | Change |
|------|--------|
| `cluster_service.py` | Remove status change for outliers, save `is_custom_label` |
| `episode_service.py` | Include `is_custom_label` in export with None handling |
| `models.py` | Add `is_custom_label` column to Image |
| `schemas.py` | Add `is_custom_label` field to Image schema |
| Migration | Add `is_custom_label` column with default `false` |
| Tests | Update expectations, add `is_custom_label` verification |

## Testing

- [x] All 51 backend tests pass
- [x] Migration applied successfully

## Note on Existing Data

Previously annotated outliers have already lost their `"outlier"` status due to this bug. Those clusters will need to be re-annotated. Going forward, all new annotations will work correctly.