### PR TITLE
fix: add Windows compatibility improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 
 # Ensure all shell scripts use LF line endings (critical for Docker on Windows)
 *.sh text eol=lf
-entrypoint.sh text eol=lf
 
 # Ensure common text files are normalized
 *.md text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,9 @@ Access:
 ```bash
 cd backend
 python -m venv venv
-source venv/bin/activate      # macOS/Linux
-# venv\Scripts\activate       # Windows (PowerShell or CMD)
+source venv/bin/activate                        # macOS/Linux
+# .\venv\Scripts\Activate.ps1                   # Windows (PowerShell)
+# source venv/Scripts/activate                  # Windows (Git Bash)
 pip install -r requirements.txt
 export DATABASE_URL="postgresql://user:password@localhost:5432/clustermark"
 alembic upgrade head

--- a/README.md
+++ b/README.md
@@ -268,17 +268,16 @@ ClusterMark works on Windows using Docker Desktop. Before getting started:
    - Download from [docker.com](https://www.docker.com/products/docker-desktop)
    - Ensure WSL 2 backend is enabled (recommended)
 
-2. **Configure Git for line endings** (prevents shell script errors):
-   ```bash
-   git config --global core.autocrlf input
-   ```
+2. **Use PowerShell or Git Bash** to run docker-compose commands
 
-3. **Use PowerShell or Git Bash** to run docker-compose commands
-
-4. **If you see "bad interpreter" or `/bin/bash^M` errors**:
+3. **If you see "bad interpreter" or `/bin/bash^M` errors** (only affects clones made before this fix):
    ```bash
-   # Re-clone the repository with correct line endings
-   git clone --config core.autocrlf=input https://github.com/yibeichan/clustermark.git
+   # Option A: Re-clone the repository
+   git clone https://github.com/yibeichan/clustermark.git
+   
+   # Option B: Fix line endings in existing clone
+   git add . --renormalize
+   git commit -m "Normalize line endings"
    ```
 
 ---


### PR DESCRIPTION
## Summary

This PR ensures ClusterMark works properly on Windows with Docker Desktop by addressing line ending issues and improving documentation.

## Changes

### New File: `.gitattributes`
- Enforces LF line endings for shell scripts (`*.sh`, `entrypoint.sh`)
- Prevents the common Windows issue where `entrypoint.sh` gets CRLF line endings, causing `#!/bin/bash\r` "bad interpreter" errors in Docker

### Updated: `README.md`
Added new **Windows Users** section under Troubleshooting with:
- Docker Desktop installation link
- Git `autocrlf` configuration instructions
- Fix for "bad interpreter" errors
- PowerShell/Git Bash recommendation

### Updated: `CONTRIBUTING.md`
- Made Windows venv activation command more explicit with separate lines for macOS/Linux vs Windows

## Why This Is Needed

When Windows users clone the repository with Git's default `core.autocrlf=true` setting, text files may get CRLF line endings. The `backend/entrypoint.sh` script runs inside a Linux Docker container and will fail with:

```
/bin/bash^M: bad interpreter: No such file or directory
```

The `.gitattributes` file fixes this by forcing LF endings for shell scripts, regardless of the user's Git configuration.

## Testing

- [x] Created `.gitattributes` with proper shell script handling
- [ ] Verify on Windows machine that `docker-compose up --build` works correctly