### PR TITLE
fix: auto-close inspector when pile becomes empty

### DIFF
--- a/frontend/src/pages/HarmonizePage.tsx
+++ b/frontend/src/pages/HarmonizePage.tsx
@@ -116,6 +116,11 @@ export default function HarmonizePage() {
             return { ...pile, images: remainingImages };
         }).filter(p => p.images.length > 0); // Remove empty piles
 
+        // If the currently inspected pile was emptied, close the inspector
+        if (expandedPileId && !newPiles.some(p => p.id === expandedPileId)) {
+            setExpandedPileId(null);
+        }
+
         setPiles(newPiles);
         setSelectedImages(new Set());
     };


### PR DESCRIPTION
## Bug Fix

Fixes the bug where inspecting a single-image pile and moving that image to another pile leaves an empty interface with no navigation options.

## Problem

1. User inspects a pile with only 1 image
2. User moves that image to another pile
3. The pile becomes empty and is removed from the list
4. The inspector view becomes blank with no "Back" button - only "Cancel" works, which loses the move operation

## Solution

Added a check in `handleMoveImages` to detect when the currently inspected pile becomes empty after moving images. When this happens, the inspector automatically closes and returns to the pile list view.

```tsx
// If the currently inspected pile was emptied, close the inspector
if (expandedPileId && !newPiles.some(p => p.id === expandedPileId)) {
    setExpandedPileId(null);
}
```

The move operation is preserved, and the user sees the updated pile list with their changes intact.

## Testing

- [x] Build passes
- [ ] Manual test: Inspect single-image pile → move image → verify auto-return to pile list