### PR TITLE
feat: add "Other (new pile)" option to inspector move dropdown & fix Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-alpine
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY . .
 


### PR DESCRIPTION
Add ability to move selected images to a brand-new pile from the inspector view. When "Other (new pile)" is selected, a text input appears for naming the new pile. Also fix Docker build by replacing `npm ci` with `npm install` since package-lock.json is gitignored and unavailable on fresh clones.